### PR TITLE
Arbitrary messages via the signaling channel

### DIFF
--- a/simplewebrtc.bundle.js
+++ b/simplewebrtc.bundle.js
@@ -7633,7 +7633,7 @@ LocalMedia.prototype.start = function (mediaConstraints, cb) {
     getUserMedia(constraints, function (err, stream) {
         if (!err) {
             if (constraints.audio && self.config.detectSpeakingEvents) {
-                self.setupAudioMonitor(stream);
+                self.setupAudioMonitor(stream, self.config.harkOptions);
             }
             self.localStreams.push(stream);
 
@@ -7732,9 +7732,9 @@ LocalMedia.prototype.unmute = function () {
     this.emit('audioOn');
 };
 
-LocalMedia.prototype.setupAudioMonitor = function (stream) {
+LocalMedia.prototype.setupAudioMonitor = function (stream, harkOptions) {
     this._log('Setup audio');
-    var audio = hark(stream);
+    var audio = hark(stream, harkOptions);
     var self = this;
     var timeout;
 

--- a/simplewebrtc.bundle.js
+++ b/simplewebrtc.bundle.js
@@ -5147,6 +5147,8 @@ Peer.prototype.handleMessage = function (message) {
         this.parent.emit('mute', {id: message.from, name: message.payload.name});
     } else if (message.type === 'unmute') {
         this.parent.emit('unmute', {id: message.from, name: message.payload.name});
+    } else {
+        this.parent.emit(message.type, {id: message.from, payload: message.payload});
     }
 };
 


### PR DESCRIPTION
With this simple change, we can easily handle arbitrary messages sent through the signaling channel, and just process them in webrtc.on('my_custom_event', function(data){

Custom messages can be sent using webrtc.sendToAll('my_custom_event', {foo: bar});

Useful to send other messages (Like the locking/unlocking of the room for example)