### PR TITLE
Allow to pass in connection when creating `SimpleWebRTC`

### DIFF
--- a/socketioconnection.js
+++ b/socketioconnection.js
@@ -1,0 +1,23 @@
+var io = require('socket.io-client');
+
+function SocketIoConnection(config) {
+    this.connection = io.connect(config.url, config.socketio);
+}
+
+SocketIoConnection.prototype.on = function (ev, fn) {
+    this.connection.on(ev, fn);
+};
+
+SocketIoConnection.prototype.emit = function (ev) {
+    this.connection.emit(arguments);
+};
+
+SocketIoConnection.prototype.getSessionid = function () {
+    return this.connection.socket.sessionid;
+};
+
+SocketIoConnection.prototype.disconnect = function () {
+    return this.connection.disconnect();
+};
+
+module.exports = SocketIoConnection;


### PR DESCRIPTION
It provides the flexibility of using different connections for
signaling. For example, it allows passing in a
[Pusher](https://pusher.com/) connection that implements the same
interface.